### PR TITLE
Fix class color reset on saving classroom settings

### DIFF
--- a/fun.py
+++ b/fun.py
@@ -236,13 +236,13 @@ def delete_classroom(class_id):
         user_data_db.update_one(query, update)
         return "complete"
 
-def save_classroom_settings(class_id,name,subtitle,description,lockMessages):
+def save_classroom_settings(class_id,name,subtitle,description,lockMessages,color):
     if check_teacher(class_id):
         new_data = {
             "name": name,
             "subtitle": subtitle,
             "description": description,
-            "coverImage": "blue",
+            "coverImage": color,
             "id": class_id,
             "settings":{
                 "messageLock":lockMessages,

--- a/main.py
+++ b/main.py
@@ -247,7 +247,7 @@ def save_classroom_settings():
             return {'status':'Fill out all fields'}
         elif (len(data["name"]) > 20 or len(data["subtitle"]) > 20 or len(data["description"]) > 100):
             return {'status':'Inputs are values are too long'}
-        status = fun.save_classroom_settings(data["classid"],data["name"],data["subtitle"],data["description"],data["messageLock"])
+        status = fun.save_classroom_settings(data["classid"],data["name"],data["subtitle"],data["description"],data["messageLock"],data["classColor"])
         return {'status':status}
 
 @app.route("/endpoint/task/save",methods=["POST"])

--- a/templates/class_settings.html
+++ b/templates/class_settings.html
@@ -137,6 +137,7 @@
             "subtitle":classSubtitle,
             "description":classDescription,
             "messageLock":messageLock,
+            "classColor":thisClass.classInfo.coverImage,
             "classid":classid
         }
         fetch('/endpoint/classroom/save', {


### PR DESCRIPTION
Saving classroom settings now retains the specified class color instead of resetting it. This change addresses the issue where the class color was lost upon saving.

Fixes #116