### PR TITLE
Redirect students after class deletion

### DIFF
--- a/fun.py
+++ b/fun.py
@@ -529,10 +529,12 @@ def get_user_classes_one_class(class_id):
 def get_class_with_users_tasks(class_id):
     userid = get_user_id()
     
-    # Use projection to only fetch the specific class we need
-    query = {"name": "classrooms"}
-    projection = {"data." + class_id: 1, "_id": 0}
-    result = global_data_db.find_one(query, projection)
+    try:
+        query = {"name": "classrooms"}
+        projection = {"data." + class_id: 1, "_id": 0}
+        result = global_data_db.find_one(query, projection)
+    except:
+        return None
     
     if not result or class_id not in result.get("data", {}):
         return None

--- a/main.py
+++ b/main.py
@@ -110,6 +110,8 @@ def class_page(classid):
     print(classid)
     if fun.login():
         user_class = fun.get_class_with_users_tasks(classid)
+        if user_class == None:
+            return redirect("/")
         return render_template("class.html",teacher=fun.check_teacher(classid),userID=fun.get_user_id(),username=fun.get_username(),page="class"+classid,classes=fun.get_user_classes(),user_class=user_class,classid=classid)
     return redirect("/")
 


### PR DESCRIPTION
Handle the scenario where a teacher deletes a class by ensuring that students are redirected to the homepage instead of encountering a server error upon reloading the page. Fixes #125