### PR TITLE
Hide Create Message button for users without permissions

### DIFF
--- a/templates/class.html
+++ b/templates/class.html
@@ -48,8 +48,8 @@
 <script>
     const leavePill = document.getElementById('leavePill');
     const settingPill = document.getElementById('settingPill');
-
-    if ({{teacher|tojson}}) {
+    const teacher = {{teacher|tojson}};
+    if (teacher) {
         settingPill.style.display = 'flex';
     }else{
         leavePill.style.display = 'flex';
@@ -78,13 +78,16 @@
     const classSubTitle = document.getElementById('classSubTitle');
 
     const thisClass = {{user_class|tojson}};
-
+    console.log(thisClass)
+    if (thisClass.classInfo.settings.messageLock && !teacher) {
+        messageButton.style.display = 'none';
+    }
     messageLock = thisClass.classInfo.settings.messageLock;
-    if (messageLock && !{{teacher|tojson}}) {
+    if (messageLock && !teacher) {
         messageButton.style.display = 'none';
     }
 
-    if (!{{teacher|tojson}}) {
+    if (!teacher) {
         createTaskButton.style.display = 'none';
     }
     classInfo = thisClass.classInfo;


### PR DESCRIPTION
The changes ensure that the Create Message button does not display for users who lack the necessary permissions to create a message. This addresses the issue where the button was visible even for unauthorized users.

Fixes #124